### PR TITLE
Fix typo 'Tempature' -> 'Temperature'

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function NestThermostatAccessory(log, name, device, deviceId, initialData, struc
 		.on('get', function (callback) {
 			var units = this.getTemperatureUnits();
 			var unitsName = units == Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? "Fahrenheit" : "Celsius";
-			this.log("Tempature unit for " + this.name + " is: " + unitsName);
+			this.log("Temperature unit for " + this.name + " is: " + unitsName);
 			if (callback) callback(null, units);
 		}.bind(this));
 


### PR DESCRIPTION
Noticed a small typo in the log output from HomeBridge.