### PR TITLE
Use Fahrenheit versions of Nest API to more accurately set and get temperatures (without rounding to nearest 0.5 Celsius)

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ function NestThermostatAccessory(log, name, device, deviceId, initialData, struc
 		.on('get', function (callback) {
 			var units = this.getTemperatureUnits();
 			var unitsName = units == Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? "Fahrenheit" : "Celsius";
-			this.log("Tempature unit for " + this.name + " is: " + unitsName);
+			this.log("Temperature unit for " + this.name + " is: " + unitsName);
 			if (callback) callback(null, units);
 		}.bind(this));
 

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -65,7 +65,7 @@ function NestThermostatAccessory(conn, log, device, structure) {
 		this.boundCharacteristics.push(characteristic);
 	}.bind(this);
 
-	bindCharacteristic(Characteristic.TemperatureDisplayUnits, "Tempature unit", this.getTemperatureUnits, null, function(val){
+	bindCharacteristic(Characteristic.TemperatureDisplayUnits, "Temperature unit", this.getTemperatureUnits, null, function(val){
 		return val == Characteristic.TemperatureDisplayUnits.FAHRENHEIT ? "Fahrenheit" : "Celsius";
 	});
 
@@ -142,7 +142,14 @@ NestThermostatAccessory.prototype.isAway = function () {
 };
 
 NestThermostatAccessory.prototype.getCurrentTemperature = function () {
-	return this.device.ambient_temperature_c;
+	switch (this.device.temperature_scale) {
+		case "F":
+			return fahrenheitToCelsius(this.device.ambient_temperature_f);
+		case "C":
+			return this.device.ambient_temperature_c;
+		default:
+			return this.device.ambient_temperature_c;
+	}
 };
 
 NestThermostatAccessory.prototype.getCurrentRelativeHumidity = function () {
@@ -153,12 +160,22 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 	switch (this.getTargetHeatingCooling()) {
 		case Characteristic.CurrentHeatingCoolingState.HEAT | Characteristic.CurrentHeatingCoolingState.COOL:
 			// Choose closest target as single target
-			var high = this.device.target_temperature_high_c;
-			var low = this.device.target_temperature_low_c;
+			if (this.device.temperature_scale = "F") {
+				var high = fahrenheitToCelsius(this.device.target_temperature_high_f);
+				var low = fahrenheitToCelsius(this.device.target_temperature_low_f);
+			} else {
+				var high = this.device.target_temperature_high_c;
+				var low = this.device.target_temperature_low_c;
+			}
 			var cur = this.getCurrentTemperature();
 			return Math.abs(high - cur) < Math.abs(cur - low) ? high : low;
 		default:
-			return this.device.target_temperature_c;
+			if (this.device.temperature_scale = "F") {
+				return fahrenheitToCelsius(this.device.target_temperature_f);
+			} else {
+				return this.device.target_temperature_c;
+			}
+			
 	}
 };
 
@@ -191,6 +208,14 @@ var callbackPromise = function(promise, callback, val){
 		});
 };
 
+function fahrenheitToCelsius(temperature) {
+	return (temperature - 32) / 1.8
+}
+
+function celsiusToFahrenheit(temperature) {
+	return (temperature * 1.8) + 32
+}
+
 NestThermostatAccessory.prototype.setTargetHeatingCooling = function (targetHeatingCooling, callback) {
 	var val = null;
 
@@ -219,24 +244,38 @@ NestThermostatAccessory.prototype.setTargetHeatingCooling = function (targetHeat
 NestThermostatAccessory.prototype.setTargetTemperature = function (targetTemperature, callback) {
 	var promise;
 
-	// Value has to be if half point increments
+	targetTemperatureF = Math.round(celsiusToFahrenheit(targetTemperature))
+	// Value has to be in half point increments
 	targetTemperature = Math.round( targetTemperature * 2 ) / 2;
+
 
 	switch (this.getTargetHeatingCooling()) {
 		case Characteristic.CurrentHeatingCoolingState.HEAT | Characteristic.CurrentHeatingCoolingState.COOL:
 			// Choose closest target as single target
-			var high = this.device.target_temperature_high_c;
-			var low = this.device.target_temperature_low_c;
+			if (this.device.temperature_scale = "F") {
+				var high = fahrenheitToCelsius(this.device.target_temperature_high_f);
+				var low = fahrenheitToCelsius(this.device.target_temperature_low_f);
+			} else {
+				var high = this.device.target_temperature_high_c;
+				var low = this.device.target_temperature_low_c;
+			}
 			var cur = this.getCurrentTemperature();
 			var isHighTemp = Math.abs(high - cur) < Math.abs(cur - low);
 			var prop = isHighTemp ? "high" : "low";
 			this.log("Setting " + prop + " target temperature for " + this.name + " to: " + targetTemperature);
-
-			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + prop + "_c"), targetTemperature);
+			if (this.device.temperature_scale = "F") {
+				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperatureF);
+			} else {
+				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
+			}
 			break;
 		default:
 			this.log("Setting target temperature for " + this.name + " to: " + targetTemperature);
-			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
+			if (this.device.temperature_scale = "F") {
+				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperatureF);
+			} else {
+				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
+			}
 			break;
 	}
 

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -266,19 +266,11 @@ NestThermostatAccessory.prototype.setTargetTemperature = function (targetTempera
 			var isHighTemp = Math.abs(high - cur) < Math.abs(cur - low);
 			var prop = isHighTemp ? "high" : "low";
 			this.log("Setting " + prop + " target temperature for " + this.name + " to: " + targetTemperature);
-			if (this.getTemperatureUnits = "F") {
-				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperature);
-			} else {
-				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
-			}
+			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + prop + "_" + this.getTemperatureUnits.toLowerCase()), targetTemperature);
 			break;
 		default:
 			this.log("Setting target temperature for " + this.name + " to: " + targetTemperature);
-			if (this.getTemperatureUnits = "F") {
-				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperature);
-			} else {
-				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
-			}
+			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + this.getTemperatureUnits.toLowerCase()), targetTemperature);
 			break;
 	}
 

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -180,7 +180,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 };
 
 NestThermostatAccessory.prototype.getTemperatureUnits = function () {
-	switch (this.getTemperatureUnits) {
+	switch (this.device.temperature_scale) {
 		case "F":
 			return Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
 		case "C":

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -142,13 +142,10 @@ NestThermostatAccessory.prototype.isAway = function () {
 };
 
 NestThermostatAccessory.prototype.getCurrentTemperature = function () {
-	switch (this.device.temperature_scale) {
-		case "F":
-			return fahrenheitToCelsius(this.device.ambient_temperature_f);
-		case "C":
-			return this.device.ambient_temperature_c;
-		default:
-			return this.device.ambient_temperature_c;
+	if (this.usesFahrenheit()) {
+		return fahrenheitToCelsius(this.device.ambient_temperature_f);
+	} else {
+		return this.device.ambient_temperature_c;
 	}
 };
 
@@ -160,7 +157,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 	switch (this.getTargetHeatingCooling()) {
 		case Characteristic.CurrentHeatingCoolingState.HEAT | Characteristic.CurrentHeatingCoolingState.COOL:
 			// Choose closest target as single target
-			if (this.getTemperatureUnits = "F") {
+			if (this.usesFahrenheit()) {
 				var high = fahrenheitToCelsius(this.device.target_temperature_high_f);
 				var low = fahrenheitToCelsius(this.device.target_temperature_low_f);
 			} else {
@@ -170,7 +167,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 			var cur = this.getCurrentTemperature();
 			return Math.abs(high - cur) < Math.abs(cur - low) ? high : low;
 		default:
-			if (this.getTemperatureUnits = "F") {
+			if (this.usesFahrenheit()) {
 				return fahrenheitToCelsius(this.device.target_temperature_f);
 			} else {
 				return this.device.target_temperature_c;
@@ -244,18 +241,18 @@ NestThermostatAccessory.prototype.setTargetHeatingCooling = function (targetHeat
 NestThermostatAccessory.prototype.setTargetTemperature = function (targetTemperature, callback) {
 	var promise;
 
-	if (this.getTemperatureUnits = "F") {
+	if (this.usesFahrenheit()) {
 		// Convert to Fahrenheit and round to nearest integer
 		targetTemperature = Math.round(celsiusToFahrenheit(targetTemperature))
 	} else {
-		// Value has to be in half point increments
+		// Celsius value has to be in half point increments
 		targetTemperature = Math.round( targetTemperature * 2 ) / 2;
 	}
 
 	switch (this.getTargetHeatingCooling()) {
 		case Characteristic.CurrentHeatingCoolingState.HEAT | Characteristic.CurrentHeatingCoolingState.COOL:
 			// Choose closest target as single target
-			if (this.getTemperatureUnits = "F") {
+			if (this.usesFahrenheit()) {
 				var high = fahrenheitToCelsius(this.device.target_temperature_high_f);
 				var low = fahrenheitToCelsius(this.device.target_temperature_low_f);
 			} else {
@@ -266,11 +263,11 @@ NestThermostatAccessory.prototype.setTargetTemperature = function (targetTempera
 			var isHighTemp = Math.abs(high - cur) < Math.abs(cur - low);
 			var prop = isHighTemp ? "high" : "low";
 			this.log("Setting " + prop + " target temperature for " + this.name + " to: " + targetTemperature);
-			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + prop + "_" + this.getTemperatureUnits.toLowerCase()), targetTemperature);
+			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + prop + "_" + (this.usesFahrenheit() ? "f" : "c")), targetTemperature);
 			break;
 		default:
 			this.log("Setting target temperature for " + this.name + " to: " + targetTemperature);
-			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + this.getTemperatureUnits.toLowerCase()), targetTemperature);
+			promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_" + (this.usesFahrenheit() ? "f" : "c")), targetTemperature);
 			break;
 	}
 
@@ -286,3 +283,7 @@ NestThermostatAccessory.prototype.setAway = function (away, callback) {
 	if (callback) callbackPromise(promise, callback, away);
 	else return promise;
 };
+
+NestThermostatAccessory.prototype.usesFahrenheit = function () {
+    return this.getTemperatureUnits() == Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
+}

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -160,7 +160,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 	switch (this.getTargetHeatingCooling()) {
 		case Characteristic.CurrentHeatingCoolingState.HEAT | Characteristic.CurrentHeatingCoolingState.COOL:
 			// Choose closest target as single target
-			if (this.device.temperature_scale = "F") {
+			if (this.getTemperatureUnits = "F") {
 				var high = fahrenheitToCelsius(this.device.target_temperature_high_f);
 				var low = fahrenheitToCelsius(this.device.target_temperature_low_f);
 			} else {
@@ -170,7 +170,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 			var cur = this.getCurrentTemperature();
 			return Math.abs(high - cur) < Math.abs(cur - low) ? high : low;
 		default:
-			if (this.device.temperature_scale = "F") {
+			if (this.getTemperatureUnits = "F") {
 				return fahrenheitToCelsius(this.device.target_temperature_f);
 			} else {
 				return this.device.target_temperature_c;
@@ -180,7 +180,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 };
 
 NestThermostatAccessory.prototype.getTemperatureUnits = function () {
-	switch (this.device.temperature_scale) {
+	switch (this.getTemperatureUnits) {
 		case "F":
 			return Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
 		case "C":
@@ -244,15 +244,18 @@ NestThermostatAccessory.prototype.setTargetHeatingCooling = function (targetHeat
 NestThermostatAccessory.prototype.setTargetTemperature = function (targetTemperature, callback) {
 	var promise;
 
-	targetTemperatureF = Math.round(celsiusToFahrenheit(targetTemperature))
-	// Value has to be in half point increments
-	targetTemperature = Math.round( targetTemperature * 2 ) / 2;
-
+	if (this.getTemperatureUnits = "F") {
+		// Convert to Fahrenheit and round to nearest integer
+		targetTemperature = Math.round(celsiusToFahrenheit(targetTemperature))
+	} else {
+		// Value has to be in half point increments
+		targetTemperature = Math.round( targetTemperature * 2 ) / 2;
+	}
 
 	switch (this.getTargetHeatingCooling()) {
 		case Characteristic.CurrentHeatingCoolingState.HEAT | Characteristic.CurrentHeatingCoolingState.COOL:
 			// Choose closest target as single target
-			if (this.device.temperature_scale = "F") {
+			if (this.getTemperatureUnits = "F") {
 				var high = fahrenheitToCelsius(this.device.target_temperature_high_f);
 				var low = fahrenheitToCelsius(this.device.target_temperature_low_f);
 			} else {
@@ -263,16 +266,16 @@ NestThermostatAccessory.prototype.setTargetTemperature = function (targetTempera
 			var isHighTemp = Math.abs(high - cur) < Math.abs(cur - low);
 			var prop = isHighTemp ? "high" : "low";
 			this.log("Setting " + prop + " target temperature for " + this.name + " to: " + targetTemperature);
-			if (this.device.temperature_scale = "F") {
-				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperatureF);
+			if (this.getTemperatureUnits = "F") {
+				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperature);
 			} else {
 				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
 			}
 			break;
 		default:
 			this.log("Setting target temperature for " + this.name + " to: " + targetTemperature);
-			if (this.device.temperature_scale = "F") {
-				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperatureF);
+			if (this.getTemperatureUnits = "F") {
+				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_f"), targetTemperature);
 			} else {
 				promise = this.conn.update(getThermostatPath(this.deviceId, "target_temperature_c"), targetTemperature);
 			}


### PR DESCRIPTION
Switched to using Fahrenheit versions of Nest API (target_temperature_f, etc) to get around rounding to the nearest 0.5 C.