### PR TITLE
Add Occupancy sensor based on Nest Away status

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -72,6 +72,10 @@ function NestThermostatAccessory(conn, log, device, structure) {
 
 	this.addAwayCharacteristic(thermostatService);
 
+	var occupancyService = this.addService(Service.OccupancySensor);
+	
+	this.bindCharacteristic(occupancyService, Characteristic.OccupancyDetected, "Nest Occupancy", this.getOccupancy, null);
+
 	this.updateData();
 }
 
@@ -156,6 +160,18 @@ function fahrenheitToCelsius(temperature) {
 function celsiusToFahrenheit(temperature) {
 	return (temperature * 1.8) + 32;
 }
+
+NestThermostatAccessory.prototype.getOccupancy = function () {
+	switch (this.structure.away) {
+        case "home":
+            return Characteristic.OccupancyDetected.OCCUPANCY_DETECTED;
+        case "away":
+        case "auto-away":
+            return Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED;
+        default:
+            return Characteristic.OccupancyDetected.OCCUPANCY_DETECTED;
+    }
+};
 
 NestThermostatAccessory.prototype.setTargetHeatingCooling = function (targetHeatingCooling, callback) {
 	var val = null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-nest",
   "description": "Nest plugin for homebridge",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/kraigm/homebridge-nest.git"


### PR DESCRIPTION
Shows us as as separate device. Allows for easier use in triggers.