### PR TITLE
API Access to Use Nest Thermostat Motion Sensor

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -67,6 +67,10 @@ function NestThermostatAccessory(conn, log, device, structure) {
 		return val + "%";
 	});
 
+	thermostatService.getCharacteristic(Characteristic.TargetTemperature)
+		.setProps({
+			minStep: 0.5
+		});
 	bindCharacteristic(Characteristic.TargetTemperature, "Target temperature", this.getTargetTemperature, this.setTargetTemperature, formatAsDisplayTemperature);
 	bindCharacteristic(Characteristic.TargetHeatingCoolingState, "Target heating", this.getTargetHeatingCooling, this.setTargetHeatingCooling, formatHeatingCoolingState);
 


### PR DESCRIPTION
@KraigM @d3bing
First pull request so bare with me. 

Before I started using hombridge/homebridge-nest, I was using the native Wink app. The Wink app could connect to the Nest Thermostat and it would use/detect the built in motion sensor(s) as a separate device. Meaning - I was able to create automations based on the Nest Thermostat sensor.
I've seen a few users in GitHub looking for a feature like this within Homebridge-Nest.
This pull request is to add this functionality. Hat's off for the current homebridge-nest functionality, works like a charm!