### PR TITLE
Added device whitelist/blacklist

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,10 +107,29 @@ NestPlatform.prototype = {
 		var generateAccessories = function(data) {
 			var foundAccessories = [];
 
+			var includeDevices = this.config["includeDevices"];
+			var excludeDevices = this.config["excludeDevices"];
+
 			var loadDevices = function(DeviceType) {
 				var list = data.devices && data.devices[DeviceType.deviceGroup];
 				for (var deviceId in list) {
 					if (list.hasOwnProperty(deviceId)) {
+
+						if(includeDevices) {
+							if(includeDevices.indexOf(deviceId) == -1) {
+								this.log("Skipping nest device " + deviceId + " because it is not in list of included devices in config");
+								continue;
+							}
+						}
+
+						if(excludeDevices) {
+							if(excludeDevices.indexOf(deviceId) != -1) {
+								this.log("Skipping nest device " + deviceId + " because it is excluded by config");
+								continue;
+							}
+						}
+
+						this.log("Adding nest device: " + deviceId);
 						var device = list[deviceId];
 						var structureId = device['structure_id'];
 						var structure = data.structures[structureId];


### PR DESCRIPTION
Issues #85, #71, and #58 all relate to having the ability of specifically including or specifically excluding devices in your nest account from being exposed to HomeKit. This is important, for example, if you have thermostats in multiple locations and you want to control them from two separate homebridge instances (and two different Home instances in HomeKit).

This PR adds the ability to specify specific devices in either a whitelist ("includeDevices") or blacklist ("excludeDevices") config parameter.