### PR TITLE
Fix Nest not responding when it has been set to away mode manually

### DIFF
--- a/lib/nest-device-accessory.js
+++ b/lib/nest-device-accessory.js
@@ -119,12 +119,8 @@ NestDeviceAccessory.prototype.isAway = function () {
     }
 };
 
-NestDeviceAccessory.prototype.isAutoAway = function () {
-    return this.structure.away == "auto-away";
-};
-
-NestDeviceAccessory.prototype.cancelAutoAway = function () {
-    return this.isAutoAway() ? this.setAway(false) : Promise.resolve();
+NestDeviceAccessory.prototype.cancelAway = function () {
+    return this.isAway() == Away.AWAY ? this.setAway(false) : Promise.resolve();
 };
 
 NestDeviceAccessory.prototype.setAway = function (away, callback) {

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -224,7 +224,7 @@ NestThermostatAccessory.prototype.setTargetTemperatureDebounced = debounce(funct
 
 	key += (usesFahrenheit ? "f" : "c");
 
-	return this.cancelAutoAway()
+	return this.cancelAway()
 		.then(this.updateDevicePropertyAsync.bind(this, key, targetTemperature, prop + "target temperature"))
 		.asCallback(callback);
 }, 5000);


### PR DESCRIPTION
Fixes #75 

If I try and change the temperature by the slider, it seems to set it, get no response back, and then seems to set it back to what it was before:

[9/16/2016, 6:09:57 PM] Target temperature for Living Room Thermostat is: 30 C
[9/16/2016, 6:09:57 PM] Target temperature for Living Room Thermostat is: 19 C

This only happened when it was set to away.

The issue here is that the Nest will only allow you to change temperature when it's not in away mode, so we have to make sure it is not.

This only used to be done when it was set to auto-away, but since I (and others) set the away mode through the API or manually set the device to away, this breaks controlling the Nest through homekit.