### PR TITLE
Fixes #157: Incorrect Fahrenheit temperature rounding

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -69,10 +69,13 @@ function NestThermostatAccessory(conn, log, device, structure) {
 		return val + "%";
 	});
 
-	thermostatService.getCharacteristic(Characteristic.TargetTemperature)
-		.setProps({
-			minStep: 0.5
-		});
+	// Only allow 0.5 increments for Celsius temperatures. HomeKit is already limited to 1-degree increments in Fahrenheit, and setting this value for Fahrenheit will causes HomeKit to incorrectly round values when convert From F to C and back.
+	if ( !this.usesFahrenheit() ) {
+		thermostatService.getCharacteristic(Characteristic.TargetTemperature)
+			.setProps({
+				minStep: 0.5
+			});
+	}
 	bindCharacteristic(Characteristic.TargetTemperature, "Target temperature", this.getTargetTemperature, this.setTargetTemperature, formatAsDisplayTemperature);
 	bindCharacteristic(Characteristic.TargetHeatingCoolingState, "Target heating", this.getTargetHeatingCooling, this.setTargetHeatingCooling, formatHeatingCoolingState);
 


### PR DESCRIPTION
Siri / HomeKit occasionally displays the incorrect temperature when the Nest's units are set to Fahrenheit.

For example, "Hey Siri set the temperature to 72-degrees" -> "Ok, I set the temperature to 71.6-degrees Fahrenheit."

This issue is a result of the "minStep" property being set to 0.5. Since HomeKit operates exclusively in Celsius, with minStep being set, HomeKit is rounding the Fahrenheit value in to the nearest 0.5 degree Celsius before setting the value, which can results in some weird rounding when converting Celsius back to Fahrenheit.

For the above: 72-degress F = 22.22-degrees C. HomeKit rounds that to 22-degrees C, which is ends up being 71.6-degrees F when converted back.

This minStep restriction is unnecessary for Fahrenheit temperatures since the when setting the temperature, the temperature is [already rounded to nearest valid unit the Nest API will accept](https://github.com/KraigM/homebridge-nest/blob/b353d511c10dae2f7bf7e13d7a52ead9060e9e25/lib/nest-thermostat-accessory.js#L198). Additionally, HomeKit is limited to 1-degree increments for Fahrenheit units.

Fixes #157